### PR TITLE
Remove discontinued Microsoft Robotics Developer Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,6 @@ commercially available industrial robot models that you can import, visualize, a
 
 [AWS RoboMaker](https://aws.amazon.com/robomaker/) is the most complete cloud solution for robotic developers to simulate, test and securely deploy robotic applications at scale. RoboMaker provides a fully-managed, scalable infrastructure for simulation that customers use for multi-robot simulation and CI/CD integration with regression testing in simulation.
 
-[Microsoft Robotics Developer Studio](https://www.microsoft.com/en-us/download/details.aspx?id=29081)  is a free .NET-based programming environment for building robotics applications. 
-
 [Visual Studio Code Extension for ROS](https://github.com/ms-iot/vscode-ros) is an extension provides support for Robot Operating System (ROS) development.
 
 [Azure Kinect ROS Driver](https://github.com/microsoft/azure_kinect_ros_driver) is a node which publishes sensor data from the [Azure Kinect Developer Kit](https://azure.microsoft.com/en-us/services/kinect-dk/) to the [Robot Operating System (ROS)](http://www.ros.org/). Developers working with ROS can use this node to connect an Azure Kinect Developer Kit to an existing ROS installation.


### PR DESCRIPTION
The MRDS link 404s, and <https://en.wikipedia.org/wiki/Microsoft_Robotics_Developer_Studio> states the product has been discontinued for quite some time.